### PR TITLE
Fix color parsing bug for 'C' class

### DIFF
--- a/src/TextTv.Cli.Tests/TextParsingHelperTests.cs
+++ b/src/TextTv.Cli.Tests/TextParsingHelperTests.cs
@@ -35,6 +35,21 @@ public class TextParsingHelperTests
         // Assert
         Assert.AreEqual(ConsoleColor.Cyan, color);
     }
+
+    [TestMethod]
+    public void DetermineTextColor_CyanForClassAttribute()
+    {
+        // Arrange
+        var doc = new HtmlDocument();
+        doc.LoadHtml("<div class='C'>Secondary Text</div>");
+        var node = doc.DocumentNode.SelectSingleNode("//div");
+
+        // Act
+        var color = TextParsingHelper.DetermineTextColor(node!);
+
+        // Assert
+        Assert.AreEqual(ConsoleColor.Cyan, color);
+    }
     
     [TestMethod]
     public void DetermineTextColor_WhiteForRegularText()

--- a/src/TextTv.Cli/Helpers/TextParsingHelper.cs
+++ b/src/TextTv.Cli/Helpers/TextParsingHelper.cs
@@ -22,7 +22,8 @@ public static class TextParsingHelper
                           node.InnerHtml.Contains("transform:scaleY(2)") ||
                           node.InnerHtml.Contains("bgY");
                           
-        bool isCyan = node.InnerHtml.Contains("bgC") || 
+        bool isCyan = classes.Contains("C") ||
+                      node.InnerHtml.Contains("bgC") ||
                       node.InnerHtml.Contains("Cyan") ||
                       node.GetAttributeValue("style", "").Contains("Cyan");
         


### PR DESCRIPTION
## Summary
- fix cyan color detection in `TextParsingHelper`
- add regression test for the bug

## Testing
- `dotnet test src/TextTv.Cli.Tests/TextTv.Cli.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_683f68ab419c8329b6451e431fdd8a24